### PR TITLE
📞 Part 3 | Using Preload Scripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,8 @@
 <body>
     <h1>Hello from Electron renderer!</h1>
     <p>👋</p>
+    <p id="info"></p>
 </body>
+<script src="./renderer.js"></script>
 
 </html>

--- a/main.js
+++ b/main.js
@@ -1,15 +1,20 @@
-const { app, BrowserWindow } = require('electron')
+const { app, BrowserWindow, ipcMain } = require('electron')
+const path = require('node:path')
 
 const createWindow = () => {
     const win = new BrowserWindow({
         width: 800,
-        height: 600
+        height: 600,
+        webPreferences: {
+            preload: path.join(__dirname, 'preload.js')
+        }
     })
 
     win.loadFile('index.html')
 }
 
 app.whenReady().then(() => {
+    ipcMain.handle('ping', () => 'pong')
     createWindow()
 
     // Open a window if none are open (macOS)

--- a/preload.js
+++ b/preload.js
@@ -1,0 +1,9 @@
+const { contextBridge, ipcRenderer } = require('electron')
+
+contextBridge.exposeInMainWorld('versions', {
+    node: () => process.versions.node,
+    chrome: () => process.versions.chrome,
+    electron: () => process.versions.electron,
+    ping: () => ipcRenderer.invoke('ping')
+    // we can also expose variables, not just functions
+})

--- a/renderer.js
+++ b/renderer.js
@@ -1,0 +1,9 @@
+const information = document.getElementById('info')
+information.innerText = `This app is using Chrome (v${versions.chrome()}), Node.js (v${versions.node()}), and Electron (v${versions.electron()})`
+
+const func = async () => {
+    const response = await window.versions.ping()
+    console.log(response) // prints out 'pong'
+}
+
+func()


### PR DESCRIPTION
## Using Preload Scripts

### Augmenting the renderer with a preload script

> Add a new `preload.js` script that exposes selected properties of Electron's `process.versions` object to the renderer process in a `versions` global variable.

```js
const { contextBridge } = require('electron')

contextBridge.exposeInMainWorld('versions', {
  node: () => process.versions.node,
  chrome: () => process.versions.chrome,
  electron: () => process.versions.electron
  // we can also expose variables, not just functions
})
```

> To attach this script to your renderer process, pass its path to the webPreferences.preload option in the BrowserWindow constructor.

```js
const { app, BrowserWindow } = require('electron')
const path = require('node:path')

const createWindow = () => {
  const win = new BrowserWindow({
    width: 800,
    height: 600,
    webPreferences: {
      preload: path.join(__dirname, 'preload.js')
    }
  })

  win.loadFile('index.html')
}

app.whenReady().then(() => {
  createWindow()
})
```

> Create a `renderer.js` script that uses the **`document.getElementById`** DOM API to replace the displayed text for the HTML element with `info` as its `id` property:

```js
const information = document.getElementById('info')
information.innerText = `This app is using Chrome (v${versions.chrome()}), Node.js (v${versions.node()}), and Electron (v${versions.electron()})`
```
> Then, modify your index.html by adding a new element with info as its id property, and attach your renderer.js script:

```html
[...]
    <p>👋</p>
    <p id="info"></p>
  </body>
  <script src="./renderer.js"></script>
[...]
```

### 

> We will add a global function to the renderer called `ping()` that will return a string from the main process.
>> First, set up the `invoke` call in your preload script:

```js
const { contextBridge, ipcRenderer } = require('electron')

contextBridge.exposeInMainWorld('versions', {
// [...]
  electron: () => process.versions.electron,
  ping: () => ipcRenderer.invoke('ping')
  // we can also expose variables, not just functions
})
```

>> Then, set up your `handle` listener in the main process. We do this *before* loading the HTML file so that the handler is guaranteed to be ready before you send out the `invoke` call from the renderer.

```js
const { app, BrowserWindow, ipcMain } = require('electron/main')

// [...]

app.whenReady().then(() => {
  ipcMain.handle('ping', () => 'pong')
  createWindow()
})
```

>> Once you have the sender and receiver set up, you can now send messages from the renderer to the main process through the `'ping'` channel you just defined.

```js
const func = async () => {
  const response = await window.versions.ping()
  console.log(response) // prints out 'pong'
}

func()
```
